### PR TITLE
add upstream `needs` in bn_simulate.R

### DIFF
--- a/R/bn_simulate.R
+++ b/R/bn_simulate.R
@@ -91,6 +91,15 @@ bn_simulate <- function(bn_df, known_df=NULL, pop_size, keep_all=FALSE, .id=NULL
 
   # create list of formulae that determining missingness
   needs <- rlang::set_names(bn_ordered_unknown$needs, bn_ordered_unknown$variable)
+  # add all upstream needs
+  for (i in seq_along(needs)) {
+    if (length(needs[[i]]) > 0) {
+      for(j in seq_along(needs[[i]])) {
+        needs[[i]] <- c(needs[[needs[[i]][j]]], needs[[i]])
+      }
+      needs[[i]] <- unique(needs[[i]])
+    }
+  }
 
   # introduce NAs according to formulae in `missing_formula`
   tblsim_missing2 <- purrr::pmap_df(


### PR DESCRIPTION
The `needs` argument in `bn_simulate` was not working as desired when there were multi-generational dependencies (e.g. in the code below `covid_vax_pfizer_3_day` needs `covid_vax_pfizer_2_day` which needs `covid_vax_pfizer_1_day`). When coded as demonstrated below, `covid_vax_pfizer_2_day` is returned as desired (i.e. missing whenever `covid_vax_pfizer_1_day` is missing), but `covid_vax_pfizer_3_day` is missing only as specified in the `missing_rate` argument, with no dependency to the parent node specified by `needs`.

```
sim_list_vax <- lst(
  covid_vax_pfizer_1_day = bn_node(
    ~as.integer(runif(n=..n, firstpfizer_day, firstpfizer_day+60)),
  ),
  covid_vax_pfizer_2_day = bn_node(
    ~as.integer(runif(n=..n, covid_vax_pfizer_1_day+30, covid_vax_pfizer_1_day+60)),
    needs = c("covid_vax_pfizer_1_day"),
    missing_rate = ~0.01
  ),
  covid_vax_pfizer_3_day = bn_node(
    ~as.integer(runif(n=..n, max(covid_vax_pfizer_2_day+15,pfizerstart_day), max(covid_vax_pfizer_2_day, pfizerstart_day)+100)),
    needs = c("covid_vax_pfizer_2_day"), # only specify parent node
    missing_rate = ~0.5
  ),
)
```

This can be resolved by specifying all ancestor nodes:

```
covid_vax_pfizer_3_day = bn_node(
    ~as.integer(runif(n=..n, max(covid_vax_pfizer_2_day+15,pfizerstart_day), max(covid_vax_pfizer_2_day, pfizerstart_day)+100)),
    needs = c("covid_vax_pfizer_1_day", "covid_vax_pfizer_2_day"), # specify all ancestor nodes
    missing_rate = ~0.5
  )
```

But as it's a bit cumbersome when there are lots of dependencies, I've added some lines to bn_simulate.R which I think fix this.
