### PR TITLE
Make dd4d show up in opensafely-core.r-universe.dev search

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,8 @@ Authors@R:
 Description: Allows you to specify and sample from a Bayesian Network 
   (a.k.a. a parametric Directed Acyclic Graph, or pDAG). 
 License: MIT + file LICENSE
+URL: https://github.com/wjchulme/dd4d,
+    https://opensafely-core.r-universe.dev/dd4d
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
We now have an <https://opensafely-core.r-universe.dev/builds>. For dd4d this PR will make the yellow box at the top of its page <https://opensafely-core.r-universe.dev/dd4d> go away

![CleanShot 2024-12-11 at 16 07 52@2x](https://github.com/user-attachments/assets/37df8097-520c-4be8-8139-210a85e0bf36)
