### PR TITLE
Minor tweaks and add example from Symposium workshop to some of the helpfiles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ URL: https://github.com/wjchulme/dd4d,
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.3.2
 Imports: 
     rlang,
     dagitty,

--- a/R/all_functions.R
+++ b/R/all_functions.R
@@ -3,7 +3,7 @@
 #'
 #' @param expr a formula object
 #'
-#' @return
+#' @return A character vector with the extracted names.
 #' @export
 #'
 #' @examples

--- a/R/all_functions.R
+++ b/R/all_functions.R
@@ -4,7 +4,6 @@
 #'
 #' @return A character vector with the extracted names.
 #' @export
-#' @examples
 all_funs = function(expr){
   all.names(expr, unique=TRUE)[!(all.names(expr, unique=TRUE) %in% all.vars(expr))]
 }

--- a/R/all_functions.R
+++ b/R/all_functions.R
@@ -1,13 +1,10 @@
-
 #' Get all functions that are used in a formula  `expr`.
 #'
 #' @param expr a formula object
 #'
 #' @return A character vector with the extracted names.
 #' @export
-#'
 #' @examples
-#'
 all_funs = function(expr){
   all.names(expr, unique=TRUE)[!(all.names(expr, unique=TRUE) %in% all.vars(expr))]
 }

--- a/R/bn2dagitty.R
+++ b/R/bn2dagitty.R
@@ -1,13 +1,10 @@
-
 #' Converts a bn_df object to a dagitty object
 #'
 #' @param bn_df initialised bn_df object, with simulation instructions. Created with `bn_create`
 #'
 #' @return dagitty object
 #' @export
-#'
 #' @examples
-#'
 bn2dagitty <- function(bn_df){
   dagitty_str = purrr::map2_chr(bn_df$variable, bn_df$parents, ~paste0(.x, " <- ", "{", paste0(.y, collapse=" ") , "}"))
   dagitty::dagitty(paste0("dag {", paste0(dagitty_str, collapse=" "), "}"))

--- a/R/bn2dagitty.R
+++ b/R/bn2dagitty.R
@@ -4,7 +4,6 @@
 #'
 #' @return dagitty object
 #' @export
-#' @examples
 bn2dagitty <- function(bn_df){
   dagitty_str = purrr::map2_chr(bn_df$variable, bn_df$parents, ~paste0(.x, " <- ", "{", paste0(.y, collapse=" ") , "}"))
   dagitty::dagitty(paste0("dag {", paste0(dagitty_str, collapse=" "), "}"))

--- a/R/bn_create.R
+++ b/R/bn_create.R
@@ -18,6 +18,54 @@
 #' @return data.frame
 #' @export
 #' @examples
+#' library(dplyr)
+#' set.seed(314159)
+#' pop_n <- 1000
+#' index_date <- as.Date("2020-12-08")
+#' pfizer_name <- paste("COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc",
+#'   "for susp for inj MDV (Pfizer)")
+#' az_name <- "COVID-19 Vaccine Vaxzevria 0.5ml inj multidose vials (AstraZeneca)"
+#' # define each variable as a node in a bayesian network
+#' sim_list <- lst(
+#'
+#'   registered = bn_node(
+#'     ~ rbernoulli(n = ..n, p = 0.99)
+#'   ),
+#'   age = bn_node(
+#'     ~ as.integer(rnorm(..n, mean= 55, sd=20)),
+#'   ),
+#'   sex = bn_node(
+#'     ~ rfactor(n = ..n, levels = c("female", "male", "intersex", "unknown"),
+#'               p = c(0.50, 0.49, 0, 0.01)),
+#'     missing_rate = ~0.01
+#'   ),
+#'   diabetes = bn_node(
+#'     ~ rbernoulli(n = ..n, p = 0.10)
+#'   ),
+#'   vaccine_date1 = bn_node(
+#'     ~ runif(n = ..n, 0, 150),
+#'     missing_rate = ~0.2
+#'   ),
+#'   vaccine_date2 = bn_node(
+#'     ~ vaccine_date1 + runif(n = ..n, 3*7, 16*7),
+#'     missing_rate = ~0.1,
+#'     needs = "vaccine_date1"
+#'   ),
+#'   vaccine_product1 = bn_node(
+#'     ~ rcat(n = ..n, c(pfizer_name, az_name), c(0.5, 0.5)),
+#'     needs = "vaccine_date1"
+#'   ),
+#'   vaccine_product2 = bn_node(
+#'     ~ if_else(runif(..n) < 0.95, vaccine_product1, c(az_name)),
+#'     needs = "vaccine_date2"
+#'   ),
+#'   death_date = bn_node(
+#'     ~ runif(n = ..n,  0, 1000),
+#'     missing_rate = ~0.95
+#'   )
+#' )
+#'
+#' bn <- bn_create(sim_list,known_variables = c("pfizer_name","az_name"))
 bn_create <- function(list, known_variables=NULL){
 
 

--- a/R/bn_create.R
+++ b/R/bn_create.R
@@ -17,7 +17,6 @@
 #'
 #' @return data.frame
 #' @export
-#'
 #' @examples
 bn_create <- function(list, known_variables=NULL){
 

--- a/R/bn_node.R
+++ b/R/bn_node.R
@@ -1,4 +1,3 @@
-
 #' Specify a variable node in the network
 #'
 #' @param variable_formula A RHS-only formula specified how to simulate that variable. Use `..n` for the number of observations, which is later replaced by `pop_size` in the `bn_simulate` function.

--- a/R/bn_plot.R
+++ b/R/bn_plot.R
@@ -1,4 +1,3 @@
-
 #' Plot bn_df object
 #'
 #' @param bn_df initialised bn_df object, with simulation instructions. Created with `bn_create`
@@ -6,7 +5,6 @@
 #'
 #' @return plot
 #' @export
-#'
 #' @examples
 bn_plot <- function(bn_df, connected_only = FALSE){
 
@@ -17,4 +15,3 @@ bn_plot <- function(bn_df, connected_only = FALSE){
   }
   plot(dagitty::graphLayout(dagitty))
 }
-

--- a/R/bn_plot.R
+++ b/R/bn_plot.R
@@ -6,6 +6,60 @@
 #' @return plot
 #' @export
 #' @examples
+#' library(dplyr)
+#' set.seed(314159)
+#' pop_n <- 1000
+#' index_date <- as.Date("2020-12-08")
+#' pfizer_name <- paste("COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc",
+#'   "for susp for inj MDV (Pfizer)")
+#' az_name <- "COVID-19 Vaccine Vaxzevria 0.5ml inj multidose vials (AstraZeneca)"
+#' # define each variable as a node in a bayesian network
+#' sim_list <- lst(
+#'
+#'   registered = bn_node(
+#'     ~ rbernoulli(n = ..n, p = 0.99)
+#'   ),
+#'   age = bn_node(
+#'     ~ as.integer(rnorm(..n, mean= 55, sd=20)),
+#'   ),
+#'   sex = bn_node(
+#'     ~ rfactor(n = ..n, levels = c("female", "male", "intersex", "unknown"),
+#'               p = c(0.50, 0.49, 0, 0.01)),
+#'     missing_rate = ~0.01
+#'   ),
+#'   diabetes = bn_node(
+#'     ~ rbernoulli(n = ..n, p = 0.10)
+#'   ),
+#'   vaccine_date1 = bn_node(
+#'     ~ runif(n = ..n, 0, 150),
+#'     missing_rate = ~0.2
+#'   ),
+#'   vaccine_date2 = bn_node(
+#'     ~ vaccine_date1 + runif(n = ..n, 3*7, 16*7),
+#'     missing_rate = ~0.1,
+#'     needs = "vaccine_date1"
+#'   ),
+#'   vaccine_product1 = bn_node(
+#'     ~ rcat(n = ..n, c(pfizer_name, az_name), c(0.5, 0.5)),
+#'     needs = "vaccine_date1"
+#'   ),
+#'   vaccine_product2 = bn_node(
+#'     ~ if_else(runif(..n) < 0.95, vaccine_product1, c(az_name)),
+#'     needs = "vaccine_date2"
+#'   ),
+#'   death_date = bn_node(
+#'     ~ runif(n = ..n,  0, 1000),
+#'     missing_rate = ~0.95
+#'   )
+#' )
+#'
+#' bn <- bn_create(sim_list,known_variables = c("pfizer_name","az_name"))
+#'
+#' # plot the network
+#' bn_plot(bn)
+#'
+#' # plot the network (connected nodes only)
+#' bn_plot(bn, connected_only = TRUE)
 bn_plot <- function(bn_df, connected_only = FALSE){
 
   if(connected_only){

--- a/R/bn_simulate.R
+++ b/R/bn_simulate.R
@@ -1,4 +1,3 @@
-
 #' Simulate data from bn_df object
 #'
 #' @param bn_df initialised bn_df object, with simulation instructions. Created with `bn_create`
@@ -9,7 +8,6 @@
 #'
 #' @return tbl
 #' @export
-#'
 #' @examples
 bn_simulate <- function(bn_df, known_df=NULL, pop_size, keep_all=FALSE, .id=NULL){
 
@@ -154,4 +152,3 @@ bn_simulate <- function(bn_df, known_df=NULL, pop_size, keep_all=FALSE, .id=NULL
 
   tblout
 }
-

--- a/R/bn_simulate.R
+++ b/R/bn_simulate.R
@@ -9,6 +9,57 @@
 #' @return tbl
 #' @export
 #' @examples
+#' library(dplyr)
+#' set.seed(314159)
+#' pop_n <- 1000
+#' index_date <- as.Date("2020-12-08")
+#' pfizer_name <- paste("COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc",
+#'   "for susp for inj MDV (Pfizer)")
+#' az_name <- "COVID-19 Vaccine Vaxzevria 0.5ml inj multidose vials (AstraZeneca)"
+#' # define each variable as a node in a bayesian network
+#' sim_list <- lst(
+#'
+#'   registered = bn_node(
+#'     ~ rbernoulli(n = ..n, p = 0.99)
+#'   ),
+#'   age = bn_node(
+#'     ~ as.integer(rnorm(..n, mean= 55, sd=20)),
+#'   ),
+#'   sex = bn_node(
+#'     ~ rfactor(n = ..n, levels = c("female", "male", "intersex", "unknown"),
+#'               p = c(0.50, 0.49, 0, 0.01)),
+#'     missing_rate = ~0.01
+#'   ),
+#'   diabetes = bn_node(
+#'     ~ rbernoulli(n = ..n, p = 0.10)
+#'   ),
+#'   vaccine_date1 = bn_node(
+#'     ~ runif(n = ..n, 0, 150),
+#'     missing_rate = ~0.2
+#'   ),
+#'   vaccine_date2 = bn_node(
+#'     ~ vaccine_date1 + runif(n = ..n, 3*7, 16*7),
+#'     missing_rate = ~0.1,
+#'     needs = "vaccine_date1"
+#'   ),
+#'   vaccine_product1 = bn_node(
+#'     ~ rcat(n = ..n, c(pfizer_name, az_name), c(0.5, 0.5)),
+#'     needs = "vaccine_date1"
+#'   ),
+#'   vaccine_product2 = bn_node(
+#'     ~ if_else(runif(..n) < 0.95, vaccine_product1, c(az_name)),
+#'     needs = "vaccine_date2"
+#'   ),
+#'   death_date = bn_node(
+#'     ~ runif(n = ..n,  0, 1000),
+#'     missing_rate = ~0.95
+#'   )
+#' )
+#'
+#' bn <- bn_create(sim_list,known_variables = c("pfizer_name","az_name"))
+#'
+#' # simulate the dataset
+#' dummy_data <- bn_simulate(bn, pop_size = pop_n, keep_all = FALSE, .id = "patient_id")
 bn_simulate <- function(bn_df, known_df=NULL, pop_size, keep_all=FALSE, .id=NULL){
 
   if (is.null(known_df)) {

--- a/R/bn_simulate.R
+++ b/R/bn_simulate.R
@@ -9,6 +9,7 @@
 #' @return tbl
 #' @export
 #' @examples
+#' \dontrun{
 #' library(dplyr)
 #' set.seed(314159)
 #' pop_n <- 1000
@@ -60,6 +61,7 @@
 #'
 #' # simulate the dataset
 #' dummy_data <- bn_simulate(bn, pop_size = pop_n, keep_all = FALSE, .id = "patient_id")
+#' }
 bn_simulate <- function(bn_df, known_df=NULL, pop_size, keep_all=FALSE, .id=NULL){
 
   if (is.null(known_df)) {

--- a/R/bn_simulate.R
+++ b/R/bn_simulate.R
@@ -78,7 +78,7 @@ bn_simulate <- function(bn_df, known_df=NULL, pop_size, keep_all=FALSE, .id=NULL
     function(variable, missing_formula, simdat){
 
       mask <- eval(rlang::f_rhs(missing_formula), simdat)
-      if(class(variable)!="factor"){
+      if(!inherits(variable, "factor")){
         NA_type_ <- NA
         mode(NA_type_) <- typeof(variable)
         dplyr::if_else(!mask, variable, NA_type_)
@@ -120,7 +120,7 @@ bn_simulate <- function(bn_df, known_df=NULL, pop_size, keep_all=FALSE, .id=NULL
         mask <- rep(FALSE, nrow(simdat))
       }
 
-      if(class(variable)!="factor"){
+      if(!inherits(variable, "factor")){
         NA_type_ <- NA
         mode(NA_type_) <- typeof(variable)
         dplyr::if_else(!mask, variable, NA_type_)

--- a/R/rcat.R
+++ b/R/rcat.R
@@ -9,7 +9,7 @@
 #' @export
 #'
 #' @examples
-#' #' rcat(n=10, levels=c("a","b"), p=c(0.2,0.8))
+#' rcat(n=10, levels=c("a","b"), p=c(0.2,0.8))
 rcat <- function(n, levels, p){
   sample(x=levels, size=n, replace=TRUE, prob=p)
 }

--- a/R/rcat.R
+++ b/R/rcat.R
@@ -13,4 +13,3 @@
 rcat <- function(n, levels, p){
   sample(x=levels, size=n, replace=TRUE, prob=p)
 }
-

--- a/R/rfactor.R
+++ b/R/rfactor.R
@@ -9,7 +9,7 @@
 #' @export
 #'
 #' @examples
-#' #' rfactor(n=10, levels=c("a","b"), p=c(0.2,0.8))
+#' rfactor(n=10, levels=c("a","b"), p=c(0.2,0.8))
 rfactor <- function(n, levels, p){
   x <- sample(x=levels, size=n, replace=TRUE, prob=p)
   factor(x = x, levels = levels)

--- a/R/rfactor.R
+++ b/R/rfactor.R
@@ -1,4 +1,3 @@
-#
 #' Random factor variables
 #'
 #' @param n number of samples
@@ -14,8 +13,3 @@ rfactor <- function(n, levels, p){
   x <- sample(x=levels, size=n, replace=TRUE, prob=p)
   factor(x = x, levels = levels)
 }
-
-
-
-
-

--- a/dd4d.Rproj
+++ b/dd4d.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: d946f6cd-7d35-453e-9b51-42bd30718e61
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/man/all_funs.Rd
+++ b/man/all_funs.Rd
@@ -10,11 +10,8 @@ all_funs(expr)
 \item{expr}{a formula object}
 }
 \value{
-
+A character vector with the extracted names.
 }
 \description{
 Get all functions that are used in a formula  \code{expr}.
-}
-\examples{
-
 }

--- a/man/bn2dagitty.Rd
+++ b/man/bn2dagitty.Rd
@@ -15,6 +15,3 @@ dagitty object
 \description{
 Converts a bn_df object to a dagitty object
 }
-\examples{
-
-}

--- a/man/bn_create.Rd
+++ b/man/bn_create.Rd
@@ -24,3 +24,53 @@ given dataset, which can be passed to bn_simulate
 whilst variable_formula is the variable name itself, this is to help with the bn_simulate function
 it doesn't actually lead to self-dependence (eg var depends on var)
 }
+\examples{
+library(dplyr)
+set.seed(314159)
+pop_n <- 1000
+index_date <- as.Date("2020-12-08")
+pfizer_name <- paste("COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc",
+  "for susp for inj MDV (Pfizer)")
+az_name <- "COVID-19 Vaccine Vaxzevria 0.5ml inj multidose vials (AstraZeneca)"
+# define each variable as a node in a bayesian network
+sim_list <- lst(
+
+  registered = bn_node(
+    ~ rbernoulli(n = ..n, p = 0.99)
+  ),
+  age = bn_node(
+    ~ as.integer(rnorm(..n, mean= 55, sd=20)),
+  ),
+  sex = bn_node(
+    ~ rfactor(n = ..n, levels = c("female", "male", "intersex", "unknown"),
+              p = c(0.50, 0.49, 0, 0.01)),
+    missing_rate = ~0.01
+  ),
+  diabetes = bn_node(
+    ~ rbernoulli(n = ..n, p = 0.10)
+  ),
+  vaccine_date1 = bn_node(
+    ~ runif(n = ..n, 0, 150),
+    missing_rate = ~0.2
+  ),
+  vaccine_date2 = bn_node(
+    ~ vaccine_date1 + runif(n = ..n, 3*7, 16*7),
+    missing_rate = ~0.1,
+    needs = "vaccine_date1"
+  ),
+  vaccine_product1 = bn_node(
+    ~ rcat(n = ..n, c(pfizer_name, az_name), c(0.5, 0.5)),
+    needs = "vaccine_date1"
+  ),
+  vaccine_product2 = bn_node(
+    ~ if_else(runif(..n) < 0.95, vaccine_product1, c(az_name)),
+    needs = "vaccine_date2"
+  ),
+  death_date = bn_node(
+    ~ runif(n = ..n,  0, 1000),
+    missing_rate = ~0.95
+  )
+)
+
+bn <- bn_create(sim_list,known_variables = c("pfizer_name","az_name"))
+}

--- a/man/bn_plot.Rd
+++ b/man/bn_plot.Rd
@@ -17,3 +17,59 @@ plot
 \description{
 Plot bn_df object
 }
+\examples{
+library(dplyr)
+set.seed(314159)
+pop_n <- 1000
+index_date <- as.Date("2020-12-08")
+pfizer_name <- paste("COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc",
+  "for susp for inj MDV (Pfizer)")
+az_name <- "COVID-19 Vaccine Vaxzevria 0.5ml inj multidose vials (AstraZeneca)"
+# define each variable as a node in a bayesian network
+sim_list <- lst(
+
+  registered = bn_node(
+    ~ rbernoulli(n = ..n, p = 0.99)
+  ),
+  age = bn_node(
+    ~ as.integer(rnorm(..n, mean= 55, sd=20)),
+  ),
+  sex = bn_node(
+    ~ rfactor(n = ..n, levels = c("female", "male", "intersex", "unknown"),
+              p = c(0.50, 0.49, 0, 0.01)),
+    missing_rate = ~0.01
+  ),
+  diabetes = bn_node(
+    ~ rbernoulli(n = ..n, p = 0.10)
+  ),
+  vaccine_date1 = bn_node(
+    ~ runif(n = ..n, 0, 150),
+    missing_rate = ~0.2
+  ),
+  vaccine_date2 = bn_node(
+    ~ vaccine_date1 + runif(n = ..n, 3*7, 16*7),
+    missing_rate = ~0.1,
+    needs = "vaccine_date1"
+  ),
+  vaccine_product1 = bn_node(
+    ~ rcat(n = ..n, c(pfizer_name, az_name), c(0.5, 0.5)),
+    needs = "vaccine_date1"
+  ),
+  vaccine_product2 = bn_node(
+    ~ if_else(runif(..n) < 0.95, vaccine_product1, c(az_name)),
+    needs = "vaccine_date2"
+  ),
+  death_date = bn_node(
+    ~ runif(n = ..n,  0, 1000),
+    missing_rate = ~0.95
+  )
+)
+
+bn <- bn_create(sim_list,known_variables = c("pfizer_name","az_name"))
+
+# plot the network
+bn_plot(bn)
+
+# plot the network (connected nodes only)
+bn_plot(bn, connected_only = TRUE)
+}

--- a/man/bn_simulate.Rd
+++ b/man/bn_simulate.Rd
@@ -24,6 +24,7 @@ tbl
 Simulate data from bn_df object
 }
 \examples{
+\dontrun{
 library(dplyr)
 set.seed(314159)
 pop_n <- 1000
@@ -75,4 +76,5 @@ bn <- bn_create(sim_list,known_variables = c("pfizer_name","az_name"))
 
 # simulate the dataset
 dummy_data <- bn_simulate(bn, pop_size = pop_n, keep_all = FALSE, .id = "patient_id")
+}
 }

--- a/man/bn_simulate.Rd
+++ b/man/bn_simulate.Rd
@@ -23,3 +23,56 @@ tbl
 \description{
 Simulate data from bn_df object
 }
+\examples{
+library(dplyr)
+set.seed(314159)
+pop_n <- 1000
+index_date <- as.Date("2020-12-08")
+pfizer_name <- paste("COVID-19 mRNA Vaccine Comirnaty 30micrograms/0.3ml dose conc",
+  "for susp for inj MDV (Pfizer)")
+az_name <- "COVID-19 Vaccine Vaxzevria 0.5ml inj multidose vials (AstraZeneca)"
+# define each variable as a node in a bayesian network
+sim_list <- lst(
+
+  registered = bn_node(
+    ~ rbernoulli(n = ..n, p = 0.99)
+  ),
+  age = bn_node(
+    ~ as.integer(rnorm(..n, mean= 55, sd=20)),
+  ),
+  sex = bn_node(
+    ~ rfactor(n = ..n, levels = c("female", "male", "intersex", "unknown"),
+              p = c(0.50, 0.49, 0, 0.01)),
+    missing_rate = ~0.01
+  ),
+  diabetes = bn_node(
+    ~ rbernoulli(n = ..n, p = 0.10)
+  ),
+  vaccine_date1 = bn_node(
+    ~ runif(n = ..n, 0, 150),
+    missing_rate = ~0.2
+  ),
+  vaccine_date2 = bn_node(
+    ~ vaccine_date1 + runif(n = ..n, 3*7, 16*7),
+    missing_rate = ~0.1,
+    needs = "vaccine_date1"
+  ),
+  vaccine_product1 = bn_node(
+    ~ rcat(n = ..n, c(pfizer_name, az_name), c(0.5, 0.5)),
+    needs = "vaccine_date1"
+  ),
+  vaccine_product2 = bn_node(
+    ~ if_else(runif(..n) < 0.95, vaccine_product1, c(az_name)),
+    needs = "vaccine_date2"
+  ),
+  death_date = bn_node(
+    ~ runif(n = ..n,  0, 1000),
+    missing_rate = ~0.95
+  )
+)
+
+bn <- bn_create(sim_list,known_variables = c("pfizer_name","az_name"))
+
+# simulate the dataset
+dummy_data <- bn_simulate(bn, pop_size = pop_n, keep_all = FALSE, .id = "patient_id")
+}

--- a/man/rcat.Rd
+++ b/man/rcat.Rd
@@ -20,5 +20,5 @@ a \code{character} vector
 Random categorical variables
 }
 \examples{
-#' rcat(n=10, levels=c("a","b"), p=c(0.2,0.8))
+rcat(n=10, levels=c("a","b"), p=c(0.2,0.8))
 }

--- a/man/rfactor.Rd
+++ b/man/rfactor.Rd
@@ -20,5 +20,5 @@ a \code{factor} vector
 Random factor variables
 }
 \examples{
-#' rfactor(n=10, levels=c("a","b"), p=c(0.2,0.8))
+rfactor(n=10, levels=c("a","b"), p=c(0.2,0.8))
 }


### PR DESCRIPTION
This

* Removes the duplicated Roxygen comment symbols from the helpfiles for `rcat()` and `rfactor()`.
* Fixes the R CMD check note about using `class() == `.
* Adds the example from your Symposium workshop to the bn_simulate, bn_plot, and bn_create helpfiles.